### PR TITLE
Update chat.py

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -16,9 +16,6 @@ class Bot(commands.Bot):
     async def event_message(self, ctx: commands.Context):
         print(f"{ctx.author.name} : {ctx.content}")
 
-    @commands.command()
-    async def event_message(self, ctx: commands.Context):
-        print(f"{ctx.author.name} : {ctx.content}")
 
 bot = Bot()
 bot.run()


### PR DESCRIPTION
the event_message method should not have a command decorator, because it's not a command 😽 (the program end up with an error otherwise)